### PR TITLE
【テスト2】フッター SNS アイコン追加

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import { Footer } from '@/components/Footer';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -15,8 +16,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="ja">
-      <body className={`${inter.variable} bg-bg font-sans text-text-1 antialiased`}>
-        {children}
+      <body className={`${inter.variable} flex min-h-screen flex-col bg-bg font-sans text-text-1 antialiased`}>
+        <div className="flex-1">{children}</div>
+        <Footer />
       </body>
     </html>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,79 @@
+const SNS_LINKS = [
+  {
+    label: 'Twitter / X',
+    href: 'https://twitter.com',
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-5 w-5"
+      >
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.911-5.622Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z" />
+      </svg>
+    ),
+  },
+  {
+    label: 'Instagram',
+    href: 'https://instagram.com',
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        className="h-5 w-5"
+      >
+        <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+        <circle cx="12" cy="12" r="4" />
+        <circle cx="17.5" cy="6.5" r="0.5" fill="currentColor" stroke="none" />
+      </svg>
+    ),
+  },
+  {
+    label: 'GitHub',
+    href: 'https://github.com',
+    icon: (
+      <svg
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+        className="h-5 w-5"
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.167 6.839 9.49.5.092.682-.217.682-.482 0-.237-.009-.868-.013-1.703-2.782.604-3.369-1.341-3.369-1.341-.454-1.155-1.11-1.463-1.11-1.463-.908-.62.069-.608.069-.608 1.004.07 1.532 1.032 1.532 1.032.892 1.529 2.341 1.087 2.91.831.091-.646.349-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.646 0 0 .84-.269 2.75 1.025A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.376.202 2.393.1 2.646.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.579.688.481C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10Z"
+        />
+      </svg>
+    ),
+  },
+];
+
+export function Footer() {
+  return (
+    <footer className="w-full border-t border-border bg-bg py-8">
+      <div className="mx-auto flex max-w-4xl flex-col items-center gap-4 px-6 sm:flex-row sm:justify-between">
+        <p className="text-sm text-text-2">© {new Date().getFullYear()} Cinematic Brand Site</p>
+        <ul className="flex items-center gap-4" aria-label="SNS links">
+          {SNS_LINKS.map(({ label, href, icon }) => (
+            <li key={label}>
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={label}
+                className="flex items-center justify-center rounded-full p-2 text-text-2 transition-colors duration-200 hover:bg-card hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                {icon}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
Closes #13

## Summary
- `components/Footer.tsx` を新規作成。Twitter/X・Instagram・GitHub のインライン SVG アイコンボタンを横並びで表示
- `app/layout.tsx` にフッターを追加。`min-h-screen flex-col` レイアウトでページ末尾に固定表示
- 各アイコンは `target="_blank" rel="noopener noreferrer"` で新しいタブで開く
- `aria-label` 付きでアクセシビリティ対応済み。モバイルでは縦積み、sm以上で横並び

## Test plan
- [ ] フッターに3つのSNSアイコン（Twitter/X・Instagram・GitHub）が表示される
- [ ] 各アイコンクリックで対応するSNSページが新しいタブで開く
- [ ] モバイルビューポート（375px）でも正常に表示される
- [ ] TypeScriptエラーなし（新規ファイルに関するもの）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)